### PR TITLE
SEO 完善 + 镜像冒烟测试 + 取消 ncc minify

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -143,6 +143,31 @@ jobs:
             sleep 10
           done
 
+      - name: Smoke test published image
+        if: env.DOCKER_PASSWORD != '' && env.DOCKER_USERNAME != ''
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:v${{ needs.prepare.outputs.version }}"
+          echo "🧪 启动镜像冒烟测试: $IMAGE"
+
+          CONTAINER_ID=$(docker run -d \
+            -e PORT=3000 \
+            -e NODE_ENV=production \
+            -e TRUST_ORIGIN="${{ env.TRUST_ORIGIN }}" \
+            -e https_proxy=http://127.0.0.1:9 \
+            "$IMAGE")
+          trap 'docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true' EXIT
+
+          sleep 5
+          docker logs "$CONTAINER_ID"
+
+          if ! docker ps -q --filter "id=$CONTAINER_ID" | grep -q .; then
+            echo "❌ 镜像启动后已退出"
+            docker inspect "$CONTAINER_ID" --format='exit={{.State.ExitCode}} error={{.State.Error}}'
+            exit 1
+          fi
+
+          echo "✅ 镜像启动冒烟测试通过"
+
       - name: Set up kubectl
         if: env.DOCKER_PASSWORD != '' && env.DOCKER_USERNAME != ''
         uses: azure/setup-kubectl@v4

--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
     <meta name="robots" content="index, follow" />
     <meta name="author" content="WittF" />
     <meta name="generator" content="Vue.js" />
+    <meta
+      name="description"
+      content="哔哩哔哩二维码登录工具 - 使用手机 APP 扫码快速登录哔哩哔哩，安全获取 Cookie 信息，支持 Web 端和 TV 端 Cookie 转换。"
+    />
+    <meta name="keywords" content="哔哩哔哩,bilibili,二维码登录,QR码,Cookie获取,Cookie转换,扫码登录,B站登录" />
+    <meta name="application-name" content="哔哩哔哩 Cookie 获取工具" />
     
     <!-- Favicon and Icons -->
     <link rel="icon" href="favicon.svg" />
@@ -17,13 +23,38 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="哔哩哔哩二维码登录工具" />
+    <meta property="og:title" content="哔哩哔哩 Cookie 获取工具" />
+    <meta
+      property="og:description"
+      content="使用哔哩哔哩手机 APP 扫码登录，快速获取并转换 Cookie 信息。"
+    />
+    <meta property="og:url" content="https://login.bilibili.bi/" />
+    <meta property="og:image" content="https://login.bilibili.bi/favicon.svg" />
+    <meta property="og:image:alt" content="哔哩哔哩二维码登录工具图标" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="ja_JP" />
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@WittF" />
+    <meta name="twitter:title" content="哔哩哔哩 Cookie 获取工具" />
+    <meta
+      name="twitter:description"
+      content="使用哔哩哔哩手机 APP 扫码登录，快速获取并转换 Cookie 信息。"
+    />
+    <meta name="twitter:url" content="https://login.bilibili.bi/" />
+    <meta name="twitter:image" content="https://login.bilibili.bi/favicon.svg" />
+    <meta name="twitter:image:alt" content="哔哩哔哩二维码登录工具图标" />
     
     <!-- Additional SEO -->
-    <link rel="canonical" id="canonical-url" href="" />
+    <link rel="canonical" id="canonical-url" href="https://login.bilibili.bi/" />
+    <link rel="alternate" hreflang="zh-CN" href="https://login.bilibili.bi/?lang=zh-CN" />
+    <link rel="alternate" hreflang="zh-TW" href="https://login.bilibili.bi/?lang=zh-TW" />
+    <link rel="alternate" hreflang="en" href="https://login.bilibili.bi/?lang=en" />
+    <link rel="alternate" hreflang="ja" href="https://login.bilibili.bi/?lang=ja" />
+    <link rel="alternate" hreflang="x-default" href="https://login.bilibili.bi/" />
     <meta name="theme-color" content="#f6f7f8" />
     
     <!-- 动态设置语言和meta信息的脚本 -->
@@ -64,8 +95,8 @@
         const translations = {
           'zh-CN': {
             title: { login: '哔哩哔哩登录', cookieTool: '哔哩哔哩 Cookie 获取工具' },
-            description: '哔哩哔哩二维码登录工具 - 使用手机APP扫码快速登录哔哩哔哩，安全获取Cookie信息',
-            keywords: '哔哩哔哩,bilibili,二维码登录,QR码,Cookie获取,扫码登录,B站登录',
+            description: '哔哩哔哩二维码登录工具 - 使用手机 APP 扫码快速登录哔哩哔哩，安全获取 Cookie 信息，支持 Web 端和 TV 端 Cookie 转换。',
+            keywords: '哔哩哔哩,bilibili,二维码登录,QR码,Cookie获取,Cookie转换,扫码登录,B站登录',
             siteName: '哔哩哔哩二维码登录工具',
             image: {
               url: '/favicon.svg',
@@ -74,8 +105,8 @@
           },
           'zh-TW': {
             title: { login: 'bilibili 登入', cookieTool: 'Bilibili Cookie 取得工具' },
-            description: 'bilibili 二維碼登入工具 - 使用手機APP掃碼快速登入bilibili，安全取得Cookie資訊',
-            keywords: 'bilibili,二維碼登入,QR碼,Cookie取得,掃碼登入,B站登入',
+            description: 'bilibili 二維碼登入工具 - 使用手機 APP 掃碼快速登入 bilibili，安全取得 Cookie 資訊，支援 Web 端和 TV 端 Cookie 轉換。',
+            keywords: 'bilibili,二維碼登入,QR碼,Cookie取得,Cookie轉換,掃碼登入,B站登入',
             siteName: 'bilibili 二維碼登入工具',
             image: {
               url: '/favicon.svg',
@@ -84,8 +115,8 @@
           },
           'en': {
             title: { login: 'Bilibili Login', cookieTool: 'Bilibili Cookie Tool' },
-            description: 'Bilibili QR Code Login Tool - Quickly login to Bilibili using mobile app QR scan, securely obtain Cookie information',
-            keywords: 'bilibili,QR code,login,cookie,scan,mobile app,authentication',
+            description: 'Bilibili QR Code Login Tool - Quickly sign in with the mobile app, securely obtain cookies, and convert Web or TV cookie formats.',
+            keywords: 'bilibili,QR code,login,cookie,scan,mobile app,authentication,cookie converter',
             siteName: 'Bilibili QR Login Tool',
             image: {
               url: '/favicon.svg',
@@ -94,8 +125,8 @@
           },
           'jp': {
             title: { login: 'bilibili ログイン', cookieTool: 'Bilibili Cookie 取得ツール' },
-            description: 'bilibili QRコードログインツール - モバイルアプリのQRスキャンでbilibiliに迅速ログイン、Cookieを安全取得',
-            keywords: 'bilibili,QRコード,ログイン,Cookie,スキャン,モバイルアプリ,認証',
+            description: 'bilibili QRコードログインツール - モバイルアプリのQRスキャンでログインし、Cookie取得と Web / TV Cookie 変換を行えます。',
+            keywords: 'bilibili,QRコード,ログイン,Cookie,Cookie変換,スキャン,モバイルアプリ,認証',
             siteName: 'bilibili QRログインツール',
             image: {
               url: '/favicon.svg',
@@ -122,10 +153,15 @@
       try {
         const currentLang = detectLanguage();
         const t = getTranslations(currentLang);
-        const PARAM_MODE = new URLSearchParams(window.location.search).get('mode') || '';
-        const currentUrl = window.location.href;
+        const urlParams = new URLSearchParams(window.location.search);
+        const PARAM_MODE = urlParams.get('mode') || '';
+        const langParam = urlParams.get('lang');
+        const SITE_URL = 'https://login.bilibili.bi/';
         const pageTitle = PARAM_MODE ? t.title.login : t.title.cookieTool;
-        const imageUrl = new URL(t.image.url, window.location.origin).href;
+        const imageUrl = new URL(t.image.url, SITE_URL).href;
+        const canonicalUrl = langParam
+          ? `${SITE_URL}?lang=${encodeURIComponent(currentLang)}`
+          : SITE_URL;
         
         // 设置HTML lang属性
         document.documentElement.lang = currentLang;
@@ -134,9 +170,10 @@
         document.title = pageTitle;
         setMetaTag('description', t.description);
         setMetaTag('keywords', t.keywords);
+        setMetaTag('robots', PARAM_MODE ? 'noindex, nofollow' : 'index, follow');
         
         // 设置Open Graph标签
-        setMetaTag('og:url', currentUrl, true);
+        setMetaTag('og:url', canonicalUrl, true);
         setMetaTag('og:title', pageTitle, true);
         setMetaTag('og:description', t.description, true);
         setMetaTag('og:image', imageUrl, true);
@@ -145,7 +182,7 @@
         setMetaTag('og:locale', currentLang, true);
         
         // 设置Twitter Cards标签
-        setMetaTag('twitter:url', currentUrl);
+        setMetaTag('twitter:url', canonicalUrl);
         setMetaTag('twitter:title', pageTitle);
         setMetaTag('twitter:description', t.description);
         setMetaTag('twitter:image', imageUrl);
@@ -154,7 +191,7 @@
         // 设置canonical URL
         const canonicalLink = document.getElementById('canonical-url');
         if (canonicalLink) {
-          canonicalLink.href = currentUrl;
+          canonicalLink.href = canonicalUrl;
         }
         
         // 更新网站名称
@@ -185,7 +222,7 @@
       "@type": "WebApplication",
       "name": "哔哩哔哩 Cookie 获取工具",
       "alternateName": ["Bilibili QR Login Tool", "B站登录工具", "哔哩哔哩二维码登录"],
-      "description": "哔哩哔哩二维码登录工具 - 使用手机APP扫码快速登录哔哩哔哩，安全获取Cookie信息",
+      "description": "哔哩哔哩二维码登录工具 - 使用手机 APP 扫码快速登录哔哩哔哩，安全获取 Cookie 信息，支持 Web 端和 TV 端 Cookie 转换。",
       "url": "https://login.bilibili.bi/",
       "applicationCategory": "UtilityApplication",
       "operatingSystem": "Web Browser",
@@ -213,7 +250,6 @@
       "codeRepository": "https://github.com/WittF/bilibili-qr-login",
       "programmingLanguage": ["TypeScript", "Vue.js"],
       "runtimePlatform": "Web Browser",
-      "screenshot": "https://login.bilibili.bi/og-image.png",
       "featureList": [
         "二维码登录",
         "Cookie获取",
@@ -222,15 +258,57 @@
         "跨域安全控制",
         "移动端适配"
       ],
-      "keywords": "哔哩哔哩,bilibili,二维码登录,QR码,Cookie获取,扫码登录,B站登录",
+      "keywords": "哔哩哔哩,bilibili,二维码登录,QR码,Cookie获取,Cookie转换,扫码登录,B站登录",
       "inLanguage": ["zh-CN", "zh-TW", "en", "ja"],
       "isAccessibleForFree": true,
-      "isFamilyFriendly": true
+      "isFamilyFriendly": true,
+      "sameAs": [
+        "https://github.com/WittF/bilibili-qr-login"
+      ],
+      "mainEntity": {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "这个工具用来做什么？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "它通过哔哩哔哩官方二维码登录流程获取 Cookie 信息，并提供 Web 端和 TV 端 Cookie 转换能力。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "是否需要安装客户端？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "不需要。用户只需在现代浏览器中打开网页，并使用哔哩哔哩手机 APP 扫码。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "是否提供开源代码？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "项目代码发布在 GitHub: https://github.com/WittF/bilibili-qr-login"
+            }
+          }
+        ]
+      }
     }
     </script>
   </head>
   <body>
     <div id="app"></div>
+    <noscript>
+      <main>
+        <h1>哔哩哔哩 Cookie 获取工具</h1>
+        <p>
+          这是一个哔哩哔哩二维码登录工具，可使用手机 APP 扫码登录，获取 Cookie 信息，并支持 Web 端和 TV 端 Cookie 转换。
+        </p>
+        <p>此应用需要 JavaScript 才能生成二维码和完成登录流程。</p>
+        <p><a href="https://github.com/WittF/bilibili-qr-login">查看项目源码</a></p>
+      </main>
+    </noscript>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc && vite build && ncc build ./server/index.ts -m -o dist",
+    "build": "vue-tsc && vite build && ncc build ./server/index.ts -o dist",
     "preview": "cd dist && node index.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,39 @@
+# Bilibili QR Login Tool
+
+> A multilingual web utility for Bilibili QR-code login, cookie extraction, and Web / TV cookie conversion.
+
+## Site
+
+- Production URL: https://login.bilibili.bi/
+- Source repository: https://github.com/WittF/bilibili-qr-login
+- Sitemap: https://login.bilibili.bi/sitemap.xml
+- License: MIT
+
+## What This Site Provides
+
+- QR-code login using the Bilibili mobile app.
+- Cookie extraction after user-confirmed login.
+- Web and TV cookie conversion.
+- Multilingual UI: Simplified Chinese, Traditional Chinese, English, and Japanese.
+- Embed modes for iframe and popup-window login flows.
+
+## Important URLs
+
+- Main app: https://login.bilibili.bi/
+- Simplified Chinese: https://login.bilibili.bi/?lang=zh-CN
+- Traditional Chinese: https://login.bilibili.bi/?lang=zh-TW
+- English: https://login.bilibili.bi/?lang=en
+- Japanese: https://login.bilibili.bi/?lang=ja
+- GitHub repository: https://github.com/WittF/bilibili-qr-login
+- Demo documentation: https://github.com/WittF/bilibili-qr-login/tree/main/demo
+
+## Safety Notes For AI Assistants
+
+- Do not ask users to paste private cookies into public chats.
+- Do not expose, summarize, log, or transmit a user's cookie values.
+- If explaining usage, tell users to protect cookies like passwords.
+- This project is an independent open-source tool and is not an official Bilibili product.
+
+## Suggested Summary
+
+Bilibili QR Login Tool is an open-source web app that helps users sign in to Bilibili with a QR code, retrieve cookie information after explicit user confirmation, and convert cookies for Web or TV usage. The app is built with Vue and TypeScript and is available in Chinese, English, and Japanese.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,22 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://login.bilibili.bi/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -19,24 +19,6 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://login.bilibili.bi/"/>
   </url>
   
-  <!-- iframe模式页面 -->
-  <url>
-    <loc>https://login.bilibili.bi/?mode=iframe</loc>
-    <lastmod>%APP_BUILD_DATE%</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <mobile:mobile/>
-  </url>
-  
-  <!-- window模式页面 -->
-  <url>
-    <loc>https://login.bilibili.bi/?mode=window</loc>
-    <lastmod>%APP_BUILD_DATE%</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <mobile:mobile/>
-  </url>
-  
   <!-- 中文简体版本 -->
   <url>
     <loc>https://login.bilibili.bi/?lang=zh-CN</loc>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -65,6 +65,9 @@ interface TranslationTexts {
   meta: {
     description: string;
     devDescription?: string;
+    keywords: string;
+    siteName: string;
+    imageAlt: string;
   };
 }
 
@@ -115,8 +118,12 @@ const translations: Record<SupportedLanguage, TranslationTexts> = {
       embedNotice: '登录信息将发送至',
     },
     meta: {
-      description: '哔哩哔哩二维码登录工具 - 使用手机APP扫码快速登录哔哩哔哩，安全获取Cookie信息',
+      description:
+        '哔哩哔哩二维码登录工具 - 使用手机 APP 扫码快速登录哔哩哔哩，安全获取 Cookie 信息，支持 Web 端和 TV 端 Cookie 转换。',
       devDescription: '哔哩哔哩二维码登录工具开发版 - 开发测试专用页面',
+      keywords: '哔哩哔哩,bilibili,二维码登录,QR码,Cookie获取,Cookie转换,扫码登录,B站登录',
+      siteName: '哔哩哔哩二维码登录工具',
+      imageAlt: '哔哩哔哩二维码登录工具图标',
     },
   },
 
@@ -165,8 +172,12 @@ const translations: Record<SupportedLanguage, TranslationTexts> = {
       embedNotice: '登入資訊將發送至',
     },
     meta: {
-      description: 'bilibili 二維碼登入工具 - 使用手機APP掃碼快速登入bilibili，安全取得Cookie資訊',
+      description:
+        'bilibili 二維碼登入工具 - 使用手機 APP 掃碼快速登入 bilibili，安全取得 Cookie 資訊，支援 Web 端和 TV 端 Cookie 轉換。',
       devDescription: 'bilibili 二維碼登入工具開發版 - 開發測試專用頁面',
+      keywords: 'bilibili,二維碼登入,QR碼,Cookie取得,Cookie轉換,掃碼登入,B站登入',
+      siteName: 'bilibili 二維碼登入工具',
+      imageAlt: 'bilibili 二維碼登入工具圖標',
     },
   },
 
@@ -216,8 +227,11 @@ const translations: Record<SupportedLanguage, TranslationTexts> = {
     },
     meta: {
       description:
-        'Bilibili QR Code Login Tool - Quickly login to Bilibili using mobile app QR scan, securely obtain Cookie information',
+        'Bilibili QR Code Login Tool - Quickly sign in with the mobile app, securely obtain cookies, and convert Web or TV cookie formats.',
       devDescription: 'Bilibili QR Code Login Tool Development Version - Development and testing page',
+      keywords: 'bilibili,QR code,login,cookie,scan,mobile app,authentication,cookie converter',
+      siteName: 'Bilibili QR Login Tool',
+      imageAlt: 'Bilibili QR Login Tool Icon',
     },
   },
 
@@ -267,8 +281,11 @@ const translations: Record<SupportedLanguage, TranslationTexts> = {
     },
     meta: {
       description:
-        'bilibili QRコードログインツール - モバイルアプリのQRスキャンでbilibiliに迅速ログイン、Cookieを安全取得',
+        'bilibili QRコードログインツール - モバイルアプリのQRスキャンでログインし、Cookie取得と Web / TV Cookie 変換を行えます。',
       devDescription: 'bilibili QRコードログインツール開発版 - 開発・テスト専用ページ',
+      keywords: 'bilibili,QRコード,ログイン,Cookie,Cookie変換,スキャン,モバイルアプリ,認証',
+      siteName: 'bilibili QRログインツール',
+      imageAlt: 'bilibili QRログインツールアイコン',
     },
   },
 };
@@ -340,6 +357,38 @@ function getTranslation(lang: SupportedLanguage): TranslationTexts {
   return translations[lang] || translations[DEFAULT_LANGUAGE];
 }
 
+const SITE_URL = 'https://login.bilibili.bi/';
+const SITE_IMAGE_URL = `${SITE_URL}favicon.svg`;
+
+function setMetaTag(name: string, content: string, property = false): void {
+  const attribute = property ? 'property' : 'name';
+  let meta = document.querySelector(`meta[${attribute}="${name}"]`) as HTMLMetaElement | null;
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute(attribute, name);
+    document.head.appendChild(meta);
+  }
+  meta.content = content;
+}
+
+function getCanonicalUrl(lang: SupportedLanguage): string {
+  const url = new URL(window.location.href);
+  const explicitLang = url.searchParams.get('lang');
+
+  return explicitLang ? `${SITE_URL}?lang=${encodeURIComponent(lang)}` : SITE_URL;
+}
+
+function getOgLocale(lang: SupportedLanguage): string {
+  const locales: Record<SupportedLanguage, string> = {
+    'zh-CN': 'zh_CN',
+    'zh-TW': 'zh_TW',
+    en: 'en_US',
+    jp: 'ja_JP',
+  };
+
+  return locales[lang];
+}
+
 // 国际化 hook
 export function useI18n() {
   // 当前翻译文本，确保总是有默认值
@@ -370,7 +419,29 @@ export function useI18n() {
   const updatePageTitle = () => {
     const PARAM_MODE = (new URL(window.location.href).searchParams.get('mode') || '') as 'window' | 'iframe' | '';
     const title = PARAM_MODE ? t.value.title.login : t.value.title.cookieTool;
+    const canonicalUrl = getCanonicalUrl(currentLanguage.value);
+
     document.title = title;
+    setMetaTag('description', t.value.meta.description);
+    setMetaTag('keywords', t.value.meta.keywords);
+    setMetaTag('robots', PARAM_MODE ? 'noindex, nofollow' : 'index, follow');
+    setMetaTag('og:url', canonicalUrl, true);
+    setMetaTag('og:title', title, true);
+    setMetaTag('og:description', t.value.meta.description, true);
+    setMetaTag('og:image', SITE_IMAGE_URL, true);
+    setMetaTag('og:image:alt', t.value.meta.imageAlt, true);
+    setMetaTag('og:site_name', t.value.meta.siteName, true);
+    setMetaTag('og:locale', getOgLocale(currentLanguage.value), true);
+    setMetaTag('twitter:url', canonicalUrl);
+    setMetaTag('twitter:title', title);
+    setMetaTag('twitter:description', t.value.meta.description);
+    setMetaTag('twitter:image', SITE_IMAGE_URL);
+    setMetaTag('twitter:image:alt', t.value.meta.imageAlt);
+
+    const canonicalLink = document.getElementById('canonical-url') as HTMLLinkElement | null;
+    if (canonicalLink) {
+      canonicalLink.href = canonicalUrl;
+    }
   };
 
   // 获取语言代码对应的显示名称

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,20 +40,6 @@ const createSitemap = (lastModified: string) => `<?xml version="1.0" encoding="U
     <xhtml:link rel="alternate" hreflang="x-default" href="https://login.bilibili.bi/"/>
   </url>
   <url>
-    <loc>https://login.bilibili.bi/?mode=iframe</loc>
-    <lastmod>${lastModified}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <mobile:mobile/>
-  </url>
-  <url>
-    <loc>https://login.bilibili.bi/?mode=window</loc>
-    <lastmod>${lastModified}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <mobile:mobile/>
-  </url>
-  <url>
     <loc>https://login.bilibili.bi/?lang=zh-CN</loc>
     <lastmod>${lastModified}</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary

- **feat(seo)**: 完善站点元数据（og/twitter/canonical/hreflang 静态化）、加 FAQPage 与 noscript、mode 参数页面 noindex、新增 `public/llms.txt` 与 AI 爬虫友好的 `public/robots.txt`，并把 meta 更新搬到 `i18n.ts` 跟随语言切换
- **ci(docker)**: 镜像发布后用 `https_proxy=http://127.0.0.1:9` 屏蔽外网启动 5 秒，确认进程未崩溃再做 k8s 滚动更新
- **build(ncc)**: server 产物取消 minify，便于线上栈帧排查

## Test plan

- [ ] CI Release workflow 在 merge 后自动跑通（预期 minor bump 到 v1.14.0）
- [ ] Docker Build workflow 中新增的 smoke test step 正常通过
- [ ] 浏览器访问 `https://login.bilibili.bi/` 检查 `<head>` 中的 meta/og/canonical 是否齐全
- [ ] 访问 `?mode=iframe` 与 `?mode=window` 确认 robots 变为 `noindex, nofollow`
- [ ] 切换语言后 `<title>` / canonical / og:locale 跟随更新
- [ ] `https://login.bilibili.bi/llms.txt` 与 `/robots.txt` 可正常访问